### PR TITLE
controllers: uart: add tcflush in register_uart_controller()

### DIFF
--- a/controllers/uart.c
+++ b/controllers/uart.c
@@ -111,6 +111,7 @@ int register_uart_controller(const char *file_name, int baudrate)
 		free(uart_ctrl);
 	}
 
+	tcflush(uart_ctrl->fd, TCIFLUSH);
 	ctrl = malloc(sizeof(*ctrl));
 	if (!ctrl) {
 		close(uart_ctrl->fd);


### PR DESCRIPTION
while using uart transport sometimes it is observed that there is a need to restart gbridge in order for the interface to be registered properly, adding tcflush improves the situation.

https://github.com/cfriedt/greybus-for-zephyr/pull/62
